### PR TITLE
Fixes an issue when running in the OS X terminal

### DIFF
--- a/config/global.el
+++ b/config/global.el
@@ -55,7 +55,8 @@
 
 ;; Disable default settings
 
-(scroll-bar-mode -1)
+(if window-system
+ (scroll-bar-mode -1))
 (tool-bar-mode -1)
 (menu-bar-mode -1)
 


### PR DESCRIPTION
In the version of Emacs I'm using (GNU Emacs 24.4.1, installed from Homebrew on OS X El Capitan), attempting to use emacs-haskell-config causes the following error:

 > Warning (initialization): An error occurred while loading `/Users/<my username>/.emacs.d/init.el':                                                                                             
> Symbol's function definition is void: scroll-bar-mode

Issue #9 describes also describes this issue -- I just added the changes in the [linked StackOverflow question]  (http://serverfault.com/questions/132055/how-to-check-if-emacs-is-in-gui-mode-and-execute-tool-bar-mode-only-then) to the appropriate place.